### PR TITLE
Bump checkout version to 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,9 @@ jobs:
         echo "GCOV=${{ matrix.config.gcov }}" >> $GITHUB_ENV
 
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        lfs: true
 
     - name: Install vcpkg
       run: |
@@ -106,12 +108,12 @@ jobs:
         cmake -B ${{ github.workspace }}/build . -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DNIMEDIA_TREAT_WARNINGS_AS_ERRORS=ON -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake -DNIMEDIA_PCM_TESTS=${{ matrix.config.pcm_tests }}
     
     - name: Build
-      run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.config.build_type }}   
+      run: |
+        cmake --build ${{ github.workspace }}/build --config ${{ matrix.config.build_type }}   
 
     - name: Test
       working-directory: ${{ github.workspace }}/build
       run: |
-        git lfs pull -X \"\"
         ctest --verbose -C ${{ matrix.config.build_type }} --timeout 900
 
     - name: Generate Code-Coverage results

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 *       @marcrambo
 *       @ni-nkozlowski
 *       @ni-mheppner
+*       @ni-abendrien

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Native Instruments
+Copyright (c) 2022 Native Instruments
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile


### PR DESCRIPTION
This should allow us to use the lfs option which would reduce a step in our build process. Also cleaned up some dead files and bumped the year on the license.